### PR TITLE
Fix missing sample rate option text

### DIFF
--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -660,6 +660,8 @@ Cover=Hide BG
 
 # NoRolls is a modifier defined in the SM5 engine that transforms Rolls into Holds
 NoRolls=Rolls to Holds
+44100 Hz=44100 Hz
+48000 Hz=48000 Hz
 
 [OptionTitles]
 # Top-level Service menu items


### PR DESCRIPTION
## Summary
- add `44100 Hz` and `48000 Hz` lines to `OptionNames` in `en.ini`

## Testing
- `grep -n "44100" -n Languages/en.ini`
- `grep -n "48000" -n Languages/en.ini`


------
https://chatgpt.com/codex/tasks/task_e_684426d2ea2c8329994160702eb0a380